### PR TITLE
Announce field type through get_internal_type method

### DIFF
--- a/django_sqids/field.py
+++ b/django_sqids/field.py
@@ -94,6 +94,9 @@ class SqidsField(Field):
             )
         return Sqids(min_length=min_length, alphabet=alphabet)
 
+    def get_internal_type(self):
+        return "CharField"
+
     def get_prep_value(self, value):
         if self.prefix:
             if value.startswith(self.prefix):


### PR DESCRIPTION
Helps drf-spectacular to infer the type for generating OpenAPI schema. See #3 