### PR TITLE
Add a recommendation to manually set the DJANGO_SQIDS_ALPHABET setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The following attributes can be added in settings file to set default arguments 
 1. `DJANGO_SQIDS_MIN_LENGTH`: default minimum length
 2. `DJANGO_SQIDS_ALPHABET`: default alphabet
 > **Note**
-> It is recommended that you provide a random string of alphabets for `DJANGO_SQIDS_ALPHABET` setting even if you are using the same characters as those in the default alphabet i.e. `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`. This will ensure that your IDs will be unique to you. You may use an online tool like [this one](https://codebeautify.org/shuffle-letters) to shuffle the default string.
+> It is recommended that you provide a random string of alphabets for `DJANGO_SQIDS_ALPHABET` setting even if you are using the same characters as those in the default alphabet i.e. `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`. This will ensure that your IDs will be unique to you. You may use the `shuffle_alphabet` function provided with `django-sqids` to shuffle the default string.
 
 `SqidsField` does not reqiure any arguments but the following arguments can be supplied to modify its behavior.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The following attributes can be added in settings file to set default arguments 
 1. `DJANGO_SQIDS_MIN_LENGTH`: default minimum length
 2. `DJANGO_SQIDS_ALPHABET`: default alphabet
 > **Note**
-> It is recommended that you provide a random string of alphabets for `DJANGO_SQIDS_ALPHABET` setting even if you are using the same characters as those in the default alphabet i.e. `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`. This will ensure that your IDs will be unique to you. You may use the `shuffle_alphabet` function provided with `django-sqids` to shuffle the default string.
+> It is recommended that you provide a random string of alphabets for `DJANGO_SQIDS_ALPHABET` setting (default: `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`). This will ensure that your IDs will be unique to you. You may use `python -m django_sqids.generate_random_alphabet` to get a random alphabet string.
 
 `SqidsField` does not reqiure any arguments but the following arguments can be supplied to modify its behavior.
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The following attributes can be added in settings file to set default arguments 
 
 1. `DJANGO_SQIDS_MIN_LENGTH`: default minimum length
 2. `DJANGO_SQIDS_ALPHABET`: default alphabet
+> **Note**
+> It is recommended that you provide a random string of alphabets for `DJANGO_SQIDS_ALPHABET` setting even if you are using the same characters as those in the default alphabet i.e. `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`. This will ensure that your IDs will be unique to you. You may use an online tool like [this one](https://codebeautify.org/shuffle-letters) to shuffle the default string.
 
 `SqidsField` does not reqiure any arguments but the following arguments can be supplied to modify its behavior.
 

--- a/django_sqids/generate_random_alphabet.py
+++ b/django_sqids/generate_random_alphabet.py
@@ -1,0 +1,10 @@
+import random
+
+from sqids.constants import DEFAULT_ALPHABET
+
+from .field import shuffle_alphabet
+
+if __name__ == '__main__':
+    random_seed = random.random()
+    shuffled_alphabet = shuffle_alphabet(seed=random_seed, alphabet=DEFAULT_ALPHABET)
+    print(shuffled_alphabet)


### PR DESCRIPTION
By customizing the `DJANGO_SQIDS_ALPHABET` string, we can prevent the issue of generating the same IDs as those generated by other projects using the default alphabet. 