### PR TITLE
reject sqids with many numbers

### DIFF
--- a/django_sqids/field.py
+++ b/django_sqids/field.py
@@ -106,6 +106,8 @@ class SqidsField(Field):
         decoded_values = self.sqids_instance.decode(value)
         if not decoded_values:
             return None
+        if len(decoded_values) > 1:
+            return None
         return decoded_values[0]
 
     def from_db_value(self, value, expression, connection, *args):

--- a/tests/test_django_sqids.py
+++ b/tests/test_django_sqids.py
@@ -529,3 +529,13 @@ def test_url_manually_with_prefix(client):
     assert response.status_code == 200
     assert response.context["object"] == instance
 
+def test_sqid_with_many_numbers():
+    from tests.test_app.models import TestModelWithDifferentConfig
+    instance = TestModelWithDifferentConfig.objects.create()
+    sqids_instance = TestModelWithDifferentConfig.sqid.get_sqid_instance()
+    sqid_single_number = sqids_instance.encode([instance.pk])
+    sqid_two_numbers = sqids_instance.encode([instance.pk, 42])
+
+    assert TestModelWithDifferentConfig.objects.get(sqid=sqid_single_number) == instance
+    with pytest.raises(TestModelWithDifferentConfig.DoesNotExist):
+        TestModelWithDifferentConfig.objects.get(sqid=sqid_two_numbers)


### PR DESCRIPTION
This pull request makes `django-sqids` reject sqid fields with more than one number in it.

This actually happened to me in production.  A random character sequence turned out to be a proper sqid, just with two numbers instead of one. (For example, `[1, 42]` instead of just `[1]`.)
Because `django-sqids` only looks at first number, an url with such sqid is actually valid, and in my case resolved to a page with real existing model instance.
That url then got indexed by a popular search engine, which got confused because the canonical url wouldn't match, messing up the SEO stuff.